### PR TITLE
Remove old vendor dependencies before creating new ones.

### DIFF
--- a/src/rebar3_prv_vendor_store.erl
+++ b/src/rebar3_prv_vendor_store.erl
@@ -31,6 +31,7 @@ do(State) ->
     AllDeps = rebar_state:lock(State),
     DepsDir = rebar_dir:deps_dir(State),
     VendorDir = filename:join(rebar_dir:root_dir(State), "deps"),
+    [file:delete(Filepath) || Filepath <- filelib:wildcard(filename:join(VendorDir, "*.zip"))],
     [begin
          filelib:ensure_dir(filename:join([VendorDir, "dummy.beam"])),
          DepName = binary_to_list(rebar_app_info:name(Dep)),


### PR DESCRIPTION
This small addition removes all dependency files before recreating them, thus ensuring that when dependencies are updated, the old ones get removed from the vendor directory.
