### PR TITLE
Allow more version formats

### DIFF
--- a/src/rebar3_prv_vendor_store.erl
+++ b/src/rebar3_prv_vendor_store.erl
@@ -68,7 +68,9 @@ get_vsn(Dep, State) ->
     case rebar_fetch:lock_source(Dep, State) of
         {git, _, {ref, Ref}} -> Ref;
         {pkg, _, Vsn0} -> Vsn0;
-        {pkg, _, Vsn0, _} -> Vsn0
+        {pkg, _, Vsn0, _} -> Vsn0;
+        {pkg, _, Vsn0, _, _} -> Vsn0;
+        {iex_dep, _, Vsn0} -> Vsn0
     end.
 
 -spec purge_other_versions(file:filename_all(), file:filename_all(), binary() | string()) -> list().


### PR DESCRIPTION
Some of my dependencies had version number in a new format. I added them to the plugin.